### PR TITLE
Plugin modernization

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,11 @@
-buildPlugin()
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.16</version>
+        <version>4.75</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -16,8 +16,7 @@
     <url>https://github.com/jenkinsci/agent-server-parameter-plugin</url>
     <properties>
         <!--https://www.jenkins.io/doc/developer/plugin-development/updating-parent/-->
-        <jenkins.version>2.277.1</jenkins.version>
-        <java.level>8</java.level>
+        <jenkins.version>2.387.3</jenkins.version>
     </properties>
     <licenses>
         <license>
@@ -49,8 +48,8 @@
             <dependency>
                 <!-- Pick up common dependencies for 2.164.x: https://github.com/jenkinsci/bom#usage -->
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.277.x</artifactId>
-                <version>26</version>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>2543.vfb_1a_5fb_9496d</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -60,7 +59,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.28.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -90,7 +88,6 @@
         <dependency>
             <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
             <artifactId>rebuild</artifactId>
-            <version>1.25</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/src/main/java/com/bluersw/AgentParameterDefinition.java
+++ b/src/main/java/com/bluersw/AgentParameterDefinition.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;


### PR DESCRIPTION
Proposal to update the plugin to use a more modern Jenkins base, make it compatible with JDK21, and change the outdated annotations.

The checks failed because these changes make the plugin incompatible with JDK8, and the original Jenkinsfile runs with JDK8.
Please relaunch the build with the updated Jenkinsfile.

Use this link to re-run the recipe: https://app.moderne.io/recipes/builder/lEdqIrjvJ?organizationId=SmVua2lucyBDSQ%3D%3D